### PR TITLE
Remove test-runner from dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php: [8.2, 8.1]
+        php: [8.3, 8.2, 8.1]
 
     name: P${{ matrix.php }} - ${{ matrix.os }}
 
@@ -45,4 +45,4 @@ jobs:
       - name: Execute tests
         run: |
           cd builds/production
-          php test-runner
+          ~/.phpkg/phpkg run https://github.com/php-repos/test-runner.git

--- a/Tests/PipeTest.php
+++ b/Tests/PipeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use function PhpRepos\ControlFlow\Transformation\pipe;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/UnlessTest.php
+++ b/Tests/UnlessTest.php
@@ -3,7 +3,7 @@
 namespace Tests\UnlessTest;
 
 use function PhpRepos\ControlFlow\Conditional\unless;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/WhenExistsTest.php
+++ b/Tests/WhenExistsTest.php
@@ -3,7 +3,7 @@
 namespace Tests\WhenExistsTest;
 
 use function PhpRepos\ControlFlow\Conditional\when_exists;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/Tests/WhenTest.php
+++ b/Tests/WhenTest.php
@@ -3,7 +3,7 @@
 namespace Tests\WhenTest;
 
 use function PhpRepos\ControlFlow\Conditional\when;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 
 test(

--- a/phpkg.config-lock.json
+++ b/phpkg.config-lock.json
@@ -1,28 +1,3 @@
 {
-    "packages": {
-        "https:\/\/github.com\/php-repos\/test-runner.git": {
-            "owner": "php-repos",
-            "repo": "test-runner",
-            "version": "v1.1.0",
-            "hash": "119c47953485a6ec127cd896a70e96376306a954"
-        },
-        "https:\/\/github.com\/php-repos\/cli.git": {
-            "owner": "php-repos",
-            "repo": "cli",
-            "version": "v1.0.0",
-            "hash": "9d8bd24f9d31b5bf18bc01e89053d311495f714d"
-        },
-        "https:\/\/github.com\/php-repos\/file-manager.git": {
-            "owner": "php-repos",
-            "repo": "file-manager",
-            "version": "v2.0.0",
-            "hash": "e5104a58dd4192c95701d414373b3add3e504bff"
-        },
-        "git@github.com:php-repos\/datatype.git": {
-            "owner": "php-repos",
-            "repo": "datatype",
-            "version": "v1.0.0",
-            "hash": "e802ba8c0cb2ffe2282de401bbf9e84a4ce1316a"
-        }
-    }
+    "packages": []
 }

--- a/phpkg.config.json
+++ b/phpkg.config.json
@@ -3,14 +3,12 @@
         "PhpRepos\\ControlFlow": "Source",
         "Tests": "Tests"
     },
-    "entry-points": [],
+    "autoloads": [],
     "excludes": [],
+    "entry-points": [],
     "executables": [],
+    "import-file": "phpkg.imports.php",
     "packages-directory": "Packages",
-    "packages": {
-        "https:\/\/github.com\/php-repos\/test-runner.git": "v1.1.0"
-    },
-    "aliases": {
-        "test-runner": "https:\/\/github.com\/php-repos\/test-runner.git"
-    }
+    "packages": [],
+    "aliases": []
 }


### PR DESCRIPTION
This PR removes `test-runner` as dependency and uses run command to run tests.